### PR TITLE
fix: handle empty roles array in FinalCTA component

### DIFF
--- a/components/FinalCTA.tsx
+++ b/components/FinalCTA.tsx
@@ -23,6 +23,8 @@ const roleTypeConfig: Record<RoleType, { icon: React.ElementType; bgClass: strin
 };
 
 const FinalCTA: React.FunctionComponent<FinalCTAProps> = ({ roles }) => {
+    if (roles.length === 0) return null;
+
     const roleTypes = Object.entries(roleTypeConfig) as [RoleType, typeof roleTypeConfig[RoleType]][];
 
     return (

--- a/data/roles.json
+++ b/data/roles.json
@@ -1,14 +1,3 @@
 {
-    "roles": [
-        {
-            "title": "Senior Research Engineer – Learning to Rank",
-            "type": "Research Engineer",
-            "link": "https://careers.allegro.eu/job/Warszawa-Senior-Research-Engineer-Learning-to-Rank-00-841/1337076255/"
-        },
-        {
-            "title": "Product Analyst",
-            "type": "Product Analyst",
-            "link": "https://careers.allegro.eu/job/Warszawa-Product-Analyst-00-841/1338720655/"
-        }
-    ]
+    "roles": []
 }


### PR DESCRIPTION
This pull request removes all job roles from the `roles.json` data file and updates the `FinalCTA` component to handle the case when there are no roles to display. The main changes are:

Data update:

* Cleared the `roles` array in `data/roles.json`, meaning no job roles will be shown.

Component behavior:

* Updated the `FinalCTA` component in `components/FinalCTA.tsx` to return `null` (render nothing) if the `roles` array is empty, preventing the component from rendering when there are no roles.